### PR TITLE
Fix up URLs in docs & comments

### DIFF
--- a/Demos/ResRWDemo/FmResRWDemo.pas
+++ b/Demos/ResRWDemo/FmResRWDemo.pas
@@ -1,7 +1,7 @@
 {
   Part of a demo project for VIBinData.dll.
 
-  Copyright (c) 2022, Peter D Johnson (https://delphidabbler.com).
+  Copyright (c) 2022, Peter D Johnson (https://gravatar.com/delphidabbler).
 
   MIT License: https://delphidabbler.mit-license.org/2022-/
 }

--- a/Demos/ResRWDemo/ResRWDemo.dpr
+++ b/Demos/ResRWDemo/ResRWDemo.dpr
@@ -1,7 +1,7 @@
 {
   Part of a demo project for VIBinData.dll.
 
-  Copyright (c) 2022, Peter D Johnson (https://delphidabbler.com).
+  Copyright (c) 2022, Peter D Johnson (https://gravatar.com/delphidabbler).
 
   MIT License: https://delphidabbler.mit-license.org/2022-/
 }

--- a/Demos/Shared/ULogger.pas
+++ b/Demos/Shared/ULogger.pas
@@ -1,7 +1,7 @@
 {
   Part of a demo project for VIBinData.dll.
 
-  Copyright (c) 2022, Peter D Johnson (https://delphidabbler.com).
+  Copyright (c) 2022, Peter D Johnson (https://gravatar.com/delphidabbler).
 
   MIT License: https://delphidabbler.mit-license.org/2022-/
 }

--- a/Demos/VIReaderDemo/FmVIReaderDemo.pas
+++ b/Demos/VIReaderDemo/FmVIReaderDemo.pas
@@ -1,7 +1,7 @@
 {
   Part of a demo project for VIBinData.dll.
 
-  Copyright (c) 2022, Peter D Johnson (https://delphidabbler.com).
+  Copyright (c) 2022, Peter D Johnson (https://gravatar.com/delphidabbler).
 
   MIT License: https://delphidabbler.mit-license.org/2022-/
 }

--- a/Demos/VIReaderDemo/UVerInfoFileStream.pas
+++ b/Demos/VIReaderDemo/UVerInfoFileStream.pas
@@ -1,9 +1,9 @@
 {
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
- * obtain one at http://mozilla.org/MPL/2.0/
+ * obtain one at https://mozilla.org/MPL/2.0/
  *
- * Copyright (C) 2022, Peter Johnson (www.delphidabbler.com).
+ * Copyright (C) 2022, Peter Johnson (https://gravatar.com/delphidabbler).
  *
  * Defines a class that provides a TStream interface to a Windows version
  * information resource embedded in a file of a type that can have Windows

--- a/Docs/UserGuide.md
+++ b/Docs/UserGuide.md
@@ -314,9 +314,9 @@ First we'll define a _TStream_ descendant that can read version information from
 {
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
- * obtain one at http://mozilla.org/MPL/2.0/
+ * obtain one at https://mozilla.org/MPL/2.0/
  *
- * Copyright (C) 2022, Peter Johnson (www.delphidabbler.com).
+ * Copyright (C) 2022, Peter Johnson (https://gravatar.com/delphidabbler).
  *
  * Defines a class that provides a TStream interface to a Windows version
  * information resource embedded in a file of a type that can have Windows

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,9 +4,9 @@ The DelphiDabbler Version Information Manipulator Library (the "Library"), is an
 
 ## Source code
 
-The source code of portions of this Library is available from the [delphidabbler/vilib](https://github.com/delphidabbler/vilib) project on GitHub, under the terms of the [Mozilla Public License v2.0](https://www.mozilla.org/en-US/MPL/2.0/).
+The source code of portions of this Library is available from the [delphidabbler/vilib](https://github.com/delphidabbler/vilib) project on GitHub, under the terms of the [Mozilla Public License v2.0](https://mozilla.org/MPL/2.0/).
 
-The demo code is released under the [MIT License](https://delphidabbler.mit-license.org/2022-), with the exception of `Demos/VIReaderDemo/UVerInfoFileStream.pas` and `Demos/ResRWDemo/Vendor/PJResFile.pas` which are licensed under the [Mozilla Public License v2](https://www.mozilla.org/en-US/MPL/2.0/).
+The demo code is released under the [MIT License](https://delphidabbler.mit-license.org/2022-), with the exception of `Demos/VIReaderDemo/UVerInfoFileStream.pas` and `Demos/ResRWDemo/Vendor/PJResFile.pas` which are licensed under the [Mozilla Public License v2](https://mozilla.org/MPL/2.0/).
 
 ## Executable (binary) code
 
@@ -26,10 +26,10 @@ You may distribute the executable version, in original or modified form, with yo
 
    ~~~text
    "VIBinData.dll was written by Peter D Johnson and is copyright (C)
-   2002-2022 Peter D Johnson, www.delphidabbler.com. Portions of the
+   2002-2022 Peter D Johnson, https://gravatar.com/delphidabbler. Portions of the
    DLL's source code are available from https://github.com/delphidabbler/vilib
    under the terms of the Mozilla Public License v2.0
-   (https://www.mozilla.org/en-US/MPL/2.0/)."
+   (https://mozilla.org/MPL/2.0/)."
    ~~~
 
 5. Should the Library, or a modified version of it be redistributed on its own rather than as part of a larger work, then the following files must be included in the distribution:

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ There are also two demos programs in the `Demos` directory. See `Demos/README.md
 
 ## License and copyright
 
-The library in copyright (C) 2002-2022 Peter D Johnson, <https://delphidabbler.com>. See the file `LICENSE.md` for details of the license. Do not use `VIBinData.dll` if you do not agree with the license.
+The library in copyright (C) 2002-2022 Peter D Johnson, <https://gravatar.com/delphidabbler>. See the file `LICENSE.md` for details of the license. Do not use `VIBinData.dll` if you do not agree with the license.
 
-Portions of the library's source code are released under the [Mozilla Public License v2.0](https://www.mozilla.org/en-US/MPL/2.0/).
+Portions of the library's source code are released under the [Mozilla Public License v2.0](https://mozilla.org/MPL/2.0/).
 
 ## Redistributing the Library
 

--- a/Src/Makefile
+++ b/Src/Makefile
@@ -1,9 +1,9 @@
 # ------------------------------------------------------------------------------
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
-# obtain one at http://mozilla.org/MPL/2.0/
+# obtain one at https://mozilla.org/MPL/2.0/
 #
-# Copyright (C) 2005-2015, Peter Johnson (www.delphidabbler.com).
+# Copyright (C) 2005-2015, Peter Johnson (https://gravatar.com/delphidabbler).
 #
 # Makefile for the vilib project.
 # ------------------------------------------------------------------------------

--- a/Src/VVIBinData.vi
+++ b/Src/VVIBinData.vi
@@ -24,7 +24,7 @@ Language=2057
 Character Set=1252
 
 [String File Info]
-Comments=This is an open source library. It may be distributed under the terms of an end user license agreement available from http://www.delphidabbler.com/. The source code of portions of the library is available from http://www.delphidabbler.com/ under the Mozilla Public License v2.0 (https://www.mozilla.org/en-US/MPL/2.0/). Modified versions of the library must be plainly marked as such and must retain all copyright statements.
+Comments=This is an open source library. It may be distributed under the terms of an end user license agreement available from https://delphidabbler.com/. The source code of portions of the library is available from https://delphidabbler.com/ under the Mozilla Public License v2.0 (https://mozilla.org/MPL/2.0/). Modified versions of the library must be plainly marked as such and must retain all copyright statements.
 Company Name=DelphiDabbler
 File Description=DLL that enables binary version information data to be read from and written to streams and to be updated.
 File Version=<#F1>.<#F2>.<#F3> build <#F4>


### PR DESCRIPTION
Replace http: with https:
Use canonical URLs where possible
Standardise usage or URLs where possible

Fixes #25